### PR TITLE
Add game builder dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Game Builder Dashboard</title>
+  <style>
+    :root{ --bg:#0f1115; --panel:#161a22; --muted:#8892a6; --line:#2a3040; --acc:#9be7a8; }
+    body{margin:0; font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial; background:var(--bg); color:#e6edf3}
+    header{display:flex; align-items:center; padding:14px 16px; border-bottom:1px solid var(--line)}
+    header h1{font-size:16px; margin:0}
+    main{padding:16px; max-width:600px; margin:0 auto}
+    input{padding:8px; border-radius:8px; border:1px solid var(--line); background:#101621; color:#e6edf3}
+    button{margin-left:8px; background:#182031; color:#dbe4ff; border:1px solid #2a3856; border-radius:10px; padding:8px 10px; cursor:pointer; font-size:13px}
+    ul{list-style:none; padding:0}
+    li{padding:6px 0; display:flex; justify-content:space-between; align-items:center; border-bottom:1px solid var(--line)}
+    a{color:#9bd1ff}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Game Builder Dashboard</h1>
+  </header>
+  <main>
+    <section id="create">
+      <input id="projectName" type="text" placeholder="Project name" />
+      <button id="createProject">Create</button>
+    </section>
+    <section>
+      <h2 style="font-size:14px; color:#c9d4ee">Projects</h2>
+      <ul id="projectList"></ul>
+    </section>
+  </main>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,38 @@
+(function(){
+  function loadProjects(){
+    try { return JSON.parse(localStorage.getItem('projects') || '[]'); }
+    catch(e){ return []; }
+  }
+  function saveProjects(list){
+    localStorage.setItem('projects', JSON.stringify(list));
+  }
+  function render(){
+    const listEl = document.getElementById('projectList');
+    listEl.innerHTML = '';
+    const projects = loadProjects();
+    projects.forEach(name => {
+      const li = document.createElement('li');
+      const span = document.createElement('span');
+      span.textContent = name;
+      const open = document.createElement('a');
+      open.href = `index.html?project=${encodeURIComponent(name)}`;
+      open.textContent = 'Open';
+      li.appendChild(span);
+      li.appendChild(open);
+      listEl.appendChild(li);
+    });
+  }
+  document.getElementById('createProject').addEventListener('click', () => {
+    const input = document.getElementById('projectName');
+    const name = input.value.trim();
+    if(!name) return;
+    const projects = loadProjects();
+    if(!projects.includes(name)){
+      projects.push(name);
+      saveProjects(projects);
+    }
+    input.value = '';
+    render();
+  });
+  render();
+})();

--- a/index.html
+++ b/index.html
@@ -56,6 +56,8 @@
     <h1>⚔️ Tactical Fable</h1>
     <span class="sep">•</span>
     <span class="muted">Grid-based tactical combat in the Realms of Fable</span>
+    <span class="sep">•</span>
+    <a href="dashboard.html" class="muted">Dashboard</a>
   </header>
 
   <div class="wrap">
@@ -127,6 +129,20 @@ const CLASSES = {
   }
   // Example adjustment in attack function (pseudocode snippet):
   // if(attacker.side==='P'){ log(`Player hits for ${total}`); } else { log(`Enemy hits for ${total}`); }
+
+  const params = new URLSearchParams(location.search);
+  const projectName = params.get("project");
+  if (projectName) {
+    const header = document.querySelector("header");
+    const sep = document.createElement("span");
+    sep.className = "sep";
+    sep.textContent = "•";
+    const projectEl = document.createElement("span");
+    projectEl.className = "muted";
+    projectEl.textContent = "Project: " + projectName;
+    header.appendChild(sep);
+    header.appendChild(projectEl);
+  }
 
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add dashboard page for managing game projects
- store project names in localStorage and open game with query params
- link game page to dashboard and show selected project

## Testing
- `npm test` (fails: could not read package.json)
- `node --check dashboard.js`

------
https://chatgpt.com/codex/tasks/task_e_68b7d5de52708324a5b2de27e70bc0b2